### PR TITLE
Add vec2 flow_direction parameter for flexible river flow control

### DIFF
--- a/addons/waterways_net/Shaders/river.gdshader
+++ b/addons/waterways_net/Shaders/river.gdshader
@@ -40,6 +40,7 @@ uniform float flow_steepness : hint_range(0.0, 8.0) = 2.0;
 uniform float flow_distance : hint_range(0.0, 8.0) = 1.0;
 uniform float flow_pressure : hint_range(0.0, 8.0) = 1.0;
 uniform float flow_max : hint_range(0.0, 8.0) = 4.0;
+uniform vec2 flow_direction = vec2(1.0, 1.0);
 
 // Foam
 uniform vec4 foam_color : source_color = vec4(0.9, 0.9, 0.9, 1.0);
@@ -133,6 +134,9 @@ void fragment() {
 	}
 	
 	flow = (flow - 0.5) * 2.0; // unpack the flow vectors
+	
+	// YENİ: Flow direction'ı vektör ile kontrol et
+	flow *= flow_direction;
 	
 	// Calculate the steepness map
 	vec3 flow_viewspace = flow.x * TANGENT + flow.y * BINORMAL;


### PR DESCRIPTION
## Summary
Added `flow_direction` parameter to river shader for flexible flow control.

## Changes
- Added `uniform vec2 flow_direction` parameter
- Default value: `vec2(1.0, 1.0)` (normal flow)

## Usage Examples
- `vec2(-1.0, -1.0)` - Complete reverse flow
- `vec2(-1.0, 1.0)` - X-axis reverse only  
- `vec2(0.5, 1.0)` - Slow X, normal Y flow

## Benefits
- Allows partial direction control
- Maintains backward compatibility
- Easy to use in editor and via script